### PR TITLE
Allow to run on non-CA nodes. Requires setup.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+0.2.0
+  * Allow this to work on nodes that are not the CA. (Requires some setup.)
+
 0.1.2
   * Erm. Actually include the bit that removes the content from the catalog.
   * Added an `autobefore` to ensure this always lets a file resource correct

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ used to programmatically generate the encrypted block.
 
 **Note**: Because it requires access to each node's signed certificates, this is
 only useful on the CA node unless you distribute certificates or generate
-encrypted blocks on the CA using the `puppet node encrypt` face.
+encrypted blocks on the CA using the `puppet node encrypt` face. There is a class
+included to automate the public certificate distribution.
 
 ## Usage
 
@@ -47,6 +48,8 @@ encrypted blocks on the CA using the `puppet node encrypt` face.
       `node_encrypt::file` type.
     * This can be used to generate text to pass to other types if/when they add
       support for this module.
+* `node_encrypt::certificates`
+    * This class will synchronize certificates to all compile masters.
 
 The simplest usage is like the example shown in the [Overview](#overview). This
 defined type accepts most of the standard file parameters and simply encrypts the
@@ -96,6 +99,16 @@ The ciphertext can be generated on the CA using the `puppet node encrypt` comman
     bFaZ36l90LkyLLrrSfjah/Tdqd8cHrphofsWVFWBmM1uErX1jBuuzngIehm40pN7
     ClVbGy9Ow3zado1spWfDwekLoiU5imk77J9POy0X8w==
     -----END PKCS7-----
+
+The `node_encrypt::certificates` class can synchronize certificates across your
+infrastructure so that encryption works from all compile masters. Please be aware
+that **this class will create a filesystem mount on the CA node!**
+
+Classify all your masters, including the CA or Master of Masters, with this class.
+This will ensure that all masters have all agents' public certificates. You can
+limit access to the certificates by passing a comma-separated list of nodes as
+the `$whitelist` parameter. If the auto-detection of the CA node doesn't work,
+you can also pass the certname of the CA node as the `$ca_node` parameter.
 
 ## Ecosystem
 

--- a/lib/facter/is_ca_node.rb
+++ b/lib/facter/is_ca_node.rb
@@ -1,0 +1,5 @@
+Facter.add(:is_ca_node) do
+  setcode do
+    File.directory?("#{Puppet.settings[:ssldir]}/ca")
+  end
+end

--- a/lib/puppet_x/binford2k/node_encrypt.rb
+++ b/lib/puppet_x/binford2k/node_encrypt.rb
@@ -11,10 +11,12 @@ module Puppet_X
         raise ArgumentError, 'Can only encrypt strings' unless data.class == String
         raise ArgumentError, 'Need a node name to encrypt for' unless destination.class == String
 
-        ssldir = Puppet.settings[:ssldir]
-        cert   = OpenSSL::X509::Certificate.new(File.read("#{ssldir}/ca/ca_crt.pem"))
-        key    = OpenSSL::PKey::RSA.new(File.read("#{ssldir}/ca/ca_key.pem"), '')
-        target = OpenSSL::X509::Certificate.new(File.read("#{ssldir}/ca/signed/#{destination}.pem"))
+        ssldir   = Puppet.settings[:ssldir]
+        name     = Puppet.settings[:certname]
+        cert     = OpenSSL::X509::Certificate.new(File.read("#{ssldir}/certs/ca.pem"))
+        key      = OpenSSL::PKey::RSA.new(File.read("#{ssldir}/private_keys/#{name}.pem"), '')
+        target   = OpenSSL::X509::Certificate.new(File.read("#{ssldir}/ca/signed/#{destination}.pem")) rescue nil
+        target ||= OpenSSL::X509::Certificate.new(File.read("#{ssldir}/certs/#{destination}.pem")) # if using auto distributed certs
 
         signed = OpenSSL::PKCS7::sign(cert, key, data, [], OpenSSL::PKCS7::BINARY)
         cipher = OpenSSL::Cipher::new("AES-128-CFB")

--- a/manifests/certificates.pp
+++ b/manifests/certificates.pp
@@ -1,0 +1,53 @@
+# Class: node_encrypt::certificates
+#
+# This class distributes public certificates from your CA node to all compile
+# masters. You should classify all your masters with this class.
+#
+# It will set up a file mountpoint on the CA node, and then sync all agent public
+# certificates to the $ssldir/certs directory on each compile master, where they
+# can be used to encrypt secrets for agents.
+#
+# Parameters:
+#
+# [*ca_node*]
+# If the CA autodetection doesn't work for you, then you should put the certname
+# of your CA here.
+#
+# [*whitelist*]
+# This is a comma-separated list of all nodes who are authorized to syncronize
+# certificates from the CA node. Defaults to `*`, or all nodes.
+#
+class node_encrypt::certificates (
+  $ca_node   = undef,
+  $whitelist = '*',
+) {
+
+  if ($ca_node and $ca_node == $::clientcert) or (! $ca_node and $::is_ca_node) {
+    ini_setting { 'public certificates mountpoint path':
+      ensure            => present,
+      path              => "${::settings::confdir}/fileserver.conf",
+      section           => 'public_certificates',
+      setting           => 'path',
+      key_val_separator => ' ',
+      value             => "${::settings::ssldir}/ca/signed/",
+    }
+
+    ini_setting { 'public certificates mountpoint whitelist':
+      ensure            => present,
+      path              => "${::settings::confdir}/fileserver.conf",
+      section           => 'public_certificates',
+      setting           => 'allow',
+      key_val_separator => ' ',
+      value             => $whitelist,
+    }
+
+  }
+  else {
+    file { "${::settings::ssldir}/certs":
+      ensure  => directory,
+      recurse => true,
+      ignore  => 'pe-internal-*',
+      source  => 'puppet:///public_certificates/',
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "binford2k-node_encrypt",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "binford2k",
   "summary": "Encrypts secrets in the catalog using the agent's certificate.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds a class to automate the distribution of agent public certificates
across your infrastructure. This will create a file mount on your CA
node and then synchronize certificates to each compile master. This
assumes that your CA node is also your Master of Masters.

Simply include `node_encrypt::certificates` on all masters, including
the CA node.

Released v0.2.0.

@logicminds does this meet your needs for #1? This seems to be a little
more robust than a REST API.