### PR TITLE
add ability to specify clientcert when calling the function

### DIFF
--- a/lib/puppet/parser/functions/node_decrypt.rb
+++ b/lib/puppet/parser/functions/node_decrypt.rb
@@ -1,0 +1,9 @@
+require 'puppet_x/binford2k/node_encrypt'
+
+Puppet::Parser::Functions::newfunction(:node_decrypt,
+  :type  => :rvalue,
+  :arity => 1,
+) do |args|
+  content  = args.first
+  value = Puppet_X::Binford2k::NodeEncrypt::Value.new(content).decrypted_value
+end

--- a/lib/puppet/parser/functions/node_encrypt.rb
+++ b/lib/puppet/parser/functions/node_encrypt.rb
@@ -2,9 +2,9 @@ require 'puppet_x/binford2k/node_encrypt'
 
 Puppet::Parser::Functions::newfunction(:node_encrypt,
   :type  => :rvalue,
-  :arity => 1,
+  :arity => -1,
 ) do |args|
   content  = args.first
-  certname = self.lookupvar('clientcert')
+  certname = args[1] || self.lookupvar('clientcert')
   Puppet_X::Binford2k::NodeEncrypt.encrypt(content, certname)
 end


### PR DESCRIPTION
      * previously the node_encrypt function would assume you want
        to encrypt it for the current node.  There are some cases
        where this is not true, or where the clientcert
        does not exist.