### PR TITLE
Correctly Handle Namespace Capitalization

### DIFF
--- a/lib/puppet/parser/functions/redact.rb
+++ b/lib/puppet/parser/functions/redact.rb
@@ -36,7 +36,7 @@ DOC
 
   # find the class in the catalog matching the name of the class this was called in
   klass = self.catalog.resources.select { |res|
-    res.type == 'Class' && res.name == self.source.name.capitalize
+    res.type == 'Class' && res.name.downcase == self.source.name
   }.first
 
   # and rewrite its parameter


### PR DESCRIPTION
If a class within a namespace (the `apt::update` class for example) uses the redact function, this error is encountered:

```
Error: undefined method `parameters' for nil:NilClass`
```

This is due to resource capitalization: the `apt::update` resource is capitalized as `Apt::Update`, not `Apt::update` as produced by the `.capitalize` function, and is never found by this `.select` statement. If we instead compare the resource name, in lower case, against the class name we will get a more consistent result.