### PR TITLE
Use pseudo-relative include paths in parser-function and type.

### DIFF
--- a/lib/puppet/parser/functions/node_encrypt.rb
+++ b/lib/puppet/parser/functions/node_encrypt.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/binford2k/node_encrypt'
+require File.join(File.dirname(__FILE__), '../../..', 'puppet_x/binford2k/node_encrypt.rb')
 
 Puppet::Parser::Functions::newfunction(:node_encrypt,
   :type  => :rvalue,

--- a/lib/puppet/parser/functions/node_encrypt.rb
+++ b/lib/puppet/parser/functions/node_encrypt.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../../..', 'puppet_x/binford2k/node_encrypt.rb')
+require_relative '../../../puppet_x/binford2k/node_encrypt'
 
 Puppet::Parser::Functions::newfunction(:node_encrypt,
   :type  => :rvalue,

--- a/lib/puppet/type/node_encrypted_file.rb
+++ b/lib/puppet/type/node_encrypted_file.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../..', 'puppet_x/binford2k/node_encrypt.rb')
+require_relative '../../puppet_x/binford2k/node_encrypt'
 
 Puppet::Type.newtype(:node_encrypted_file) do
   desc "Manage the content of a file by decrypting with the agent certificate"

--- a/lib/puppet/type/node_encrypted_file.rb
+++ b/lib/puppet/type/node_encrypted_file.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/binford2k/node_encrypt'
+require File.join(File.dirname(__FILE__), '../..', 'puppet_x/binford2k/node_encrypt.rb')
 
 Puppet::Type.newtype(:node_encrypted_file) do
   desc "Manage the content of a file by decrypting with the agent certificate"


### PR DESCRIPTION
This fixes #8 and #14 in our setup (Puppet 5.2.0).

The underlying cause is described at:
https://tickets.puppetlabs.com/browse/SERVER-973
Without manually patching puppetserver's load path, the only other workaround would be to use something more complex like:
https://github.com/nanliu/puppet-archive/blob/766062a3465053ca8a326ea0b3c31648a49474a4/lib/puppet/provider/archive/default.rb#L1-L10

I guess it's patched somewhere in Puppet Enterprise's puppetserver, which might be the cause why it works for some people. 