### PR TITLE
node_encrypt.rb: Use dummy 4 byte password to read key.

### DIFF
--- a/lib/puppet_x/binford2k/node_encrypt.rb
+++ b/lib/puppet_x/binford2k/node_encrypt.rb
@@ -26,7 +26,11 @@ module Puppet_X
         end
 
         cert   = OpenSSL::X509::Certificate.new(File.read(certpath))
-        key    = OpenSSL::PKey::RSA.new(File.read(keypath), '')
+        # A dummy password with at least 4 characters is required here
+        # since Ruby 2.4 which enforces a minimum password length
+        # of 4 bytes. This is true even if the key has no password
+        # at all, otherwise Ruby fatals out.
+        key    = OpenSSL::PKey::RSA.new(File.read(keypath), '1234')
         target = OpenSSL::X509::Certificate.new(File.read(destpath))
 
         signed = OpenSSL::PKCS7::sign(cert, key, data, [], OpenSSL::PKCS7::BINARY)
@@ -39,7 +43,11 @@ module Puppet_X
         raise ArgumentError, 'Can only decrypt strings' unless data.class == String
 
         cert   = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
-        key    = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]), '')
+        # A dummy password with at least 4 characters is required here
+        # since Ruby 2.4 which enforces a minimum password length
+        # of 4 bytes. This is true even if the key has no password
+        # at all, otherwise Ruby fatals out.
+        key    = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]), '1234')
         source = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:localcacert]))
 
         store = OpenSSL::X509::Store.new

--- a/lib/puppet_x/binford2k/node_encrypt.rb
+++ b/lib/puppet_x/binford2k/node_encrypt.rb
@@ -29,7 +29,9 @@ module Puppet_X
         # A dummy password with at least 4 characters is required here
         # since Ruby 2.4 which enforces a minimum password length
         # of 4 bytes. This is true even if the key has no password
-        # at all, otherwise Ruby fatals out.
+        # at all--in which case the password we supply is ignored.
+        # We can pass in a dummy here, since we know the certificate
+        # has no password.
         key    = OpenSSL::PKey::RSA.new(File.read(keypath), '1234')
         target = OpenSSL::X509::Certificate.new(File.read(destpath))
 
@@ -43,10 +45,7 @@ module Puppet_X
         raise ArgumentError, 'Can only decrypt strings' unless data.class == String
 
         cert   = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
-        # A dummy password with at least 4 characters is required here
-        # since Ruby 2.4 which enforces a minimum password length
-        # of 4 bytes. This is true even if the key has no password
-        # at all, otherwise Ruby fatals out.
+        # Same dummy password as above.
         key    = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]), '1234')
         source = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:localcacert]))
 


### PR DESCRIPTION
Since Ruby 2.4, it is required to pass a 4 byte password,
even if the key has no password at all, otherwise it fatals out.
This leads to ugly workarounds such as these:
https://github.com/github/octocatalog-diff/blob/6093d3c24b0be8045d779b1f6cf2e56367e2e8fb/lib/octocatalog-diff/util/httparty.rb#L127
Since we know these keys always have no password, we can just use 1234.

Maybe somebody should open up a Ruby bug about this stupid design decision. 