### PR TITLE
Add Puppet 5 support to the certificates class

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,4 +2,6 @@ fixtures:
     symlinks:
         node_encrypt: "#{source_dir}"
     forge_modules:
+        stdlib: "puppetlabs/stdlib"
         inifile: "puppetlabs/inifile"
+        puppet_authorization: "puppetlabs/puppet_authorization"

--- a/README.md
+++ b/README.md
@@ -210,24 +210,19 @@ This will ensure that all masters have all agents' public certificates. Limit ac
 to the certificates by passing a comma-separated list of compile master nodes as
 the `$whitelist` parameter.
 
-**Note**:<br />
-As of Puppet 5, you'll need to set the `whitelist` to false if you don't plan to
-manage access to the certificates. This is a breaking change.
-
 Parameters:
 
-* [*whitelist*]
-    * This is a comma-separated list of all nodes who are authorized to synchronize
-      *all* certificates from the CA node. Defaults to `*`, or all nodes. Set to
-      `false` to disable whitelist management.
-
-* [*manage_hocon*]
-    * Set to `true` if you've disabled legacy `auth.conf` and are on Puppet 5.
+* [*legacy*]
+    * Set to `true` if you're still using legacy `auth.conf` on Puppet 5.
 
 * [*sort_order*]
     * If you've customized your HOCON-based `auth.conf`, set the appropriate sort
       order here. The default rule's weight is 500, so this parameter defaults to
-      `300` so it overrides the default.
+      `300` to ensure that it overrides the default.
+
+* [*whitelist*]
+    * This is deprecated and has no effect. It will be removed in the next major release.
+
 
 **Note**:<br />
 If this is applied to nodes in a flat hierarchy (i.e., non Master of Masters),
@@ -235,16 +230,13 @@ then all agents will have all public certificates synched. This is not a
 security risk, as public certificates are designed to be shared widely, but it
 is something you should be aware of.
 
-#### Managing Certificates on Open Source Puppet 5
+#### Deprecated Parameters
 
-As of Puppet 5, we can no longer automatically manage the whitelist for the
-certificates mountpoint on Open Source Puppet. This is not a problem on Puppet
-Enterprise because we can make certain assumptions about how it is configured.
-
-If you're on Open Source Puppet 5.x or greater, see
-[the documentation](https://puppet.com/docs/puppet/5.3/file_serving.html#controlling-access-to-a-custom-mount-point-in-authconf)
-for information on custom authentication rules. If you've disabled legacy `auth.conf`
-ACLS, then you can simply set `manage_hocon` to true, and optionally set a `sort_order`.
+Since public certificates are designed to be shared widely without a security
+risk, we made the decision to simplify and no longer manage a whitelist of
+compile masters allowed to access the `public_certificates` mountpoint. If you
+would like to enforce a whitelist anyway, then you can use one of the following
+methods:
 
 If you're using the legacy `auth.conf` format then you'll need to configure it
 manually by editing `$confdir/auth.conf` on the CA server. Ensure that this
@@ -255,7 +247,22 @@ parameter to `false` in your classification to disable the error.
 # Node_encrypt: Allow limited access to the 'public_certificates' mountpoint:
 path ~ ^/puppet/v3/file_(metadata|content)s?/public_certificates/
 auth yes
-allow ${whitelist}
+allow list,of,whitelisted,certnames
+```
+
+If you're using the modern HOCON based `auth.conf` format, then you can manage
+access using a Puppet resource such as the following. Ensure that the `sort_order`
+is lower than `300`, or the value you passed to `node_encrypt::certificates`.
+
+```Puppet
+puppet_authorization::rule { 'public certificates mountpoint override':
+  match_request_path   => '^/puppet/v3/file_(metadata|content)s?/public_certificates',
+  match_request_type   => 'regex',
+  match_request_method => 'get',
+  allow                => ['array', 'of', 'whitelisted', 'certnames'],
+  sort_order           => 250,
+  path                 => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -211,16 +211,53 @@ to the certificates by passing a comma-separated list of compile master nodes as
 the `$whitelist` parameter.
 
 **Note**:<br />
-If this is applied to nodes in a flat hierarchy (i.e., non Master of Masters),
-then all agents will have all public certificates synched. This is not a
-security risk, as public certificates are designed to be shared widely, but it
-is something you should be aware of.
+As of Puppet 5, you'll need to set the `whitelist` to false if you don't plan to
+manage access to the certificates. This is a breaking change.
 
 Parameters:
 
 * [*whitelist*]
     * This is a comma-separated list of all nodes who are authorized to synchronize
-      *all* certificates from the CA node. Defaults to `*`, or all nodes.
+      *all* certificates from the CA node. Defaults to `*`, or all nodes. Set to
+      `false` to disable whitelist management.
+
+* [*manage_hocon*]
+    * Set to `true` if you've disabled legacy `auth.conf` and are on Puppet 5.
+
+* [*sort_order*]
+    * If you've customized your HOCON-based `auth.conf`, set the appropriate sort
+      order here. The default rule's weight is 500, so this parameter defaults to
+      `300` so it overrides the default.
+
+**Note**:<br />
+If this is applied to nodes in a flat hierarchy (i.e., non Master of Masters),
+then all agents will have all public certificates synched. This is not a
+security risk, as public certificates are designed to be shared widely, but it
+is something you should be aware of.
+
+#### Managing Certificates on Open Source Puppet 5
+
+As of Puppet 5, we can no longer automatically manage the whitelist for the
+certificates mountpoint on Open Source Puppet. This is not a problem on Puppet
+Enterprise because we can make certain assumptions about how it is configured.
+
+If you're on Open Source Puppet 5.x or greater, see
+[the documentation](https://puppet.com/docs/puppet/5.3/file_serving.html#controlling-access-to-a-custom-mount-point-in-authconf)
+for information on custom authentication rules. If you've disabled legacy `auth.conf`
+ACLS, then you can simply set `manage_hocon` to true, and optionally set a `sort_order`.
+
+If you're using the legacy `auth.conf` format then you'll need to configure it
+manually by editing `$confdir/auth.conf` on the CA server. Ensure that this
+stanza comes before the existing `^/puppet/v3/file` rule and set the `whitelist`
+parameter to `false` in your classification to disable the error.
+
+```
+# Node_encrypt: Allow limited access to the 'public_certificates' mountpoint:
+path ~ ^/puppet/v3/file_(metadata|content)s?/public_certificates/
+auth yes
+allow ${whitelist}
+```
+
 
 ### Using on masterless infrastructures
 

--- a/manifests/certificates.pp
+++ b/manifests/certificates.pp
@@ -18,31 +18,84 @@
 #
 # [*whitelist*]
 # This is a comma-separated list of all nodes who are authorized to synchronize
-# *all* certificates from the CA node. Defaults to `*`, or all nodes.
+# *all* certificates from the CA node. Defaults to `*`, or all nodes. Set to
+# `false` to disable whitelist management.
 #
+# [*manage_hocon*]
+#  Set to `true` if you've disabled legacy `auth.conf` and are on Puppet 5.
+#
+# [*sort_order*]
+# If you've customized your HOCON-based `auth.conf`, set the appropriate sort
+# order here. The default rule's weight is 500, so this parameter defaults to
+# `300` so it overrides the default.
+
 class node_encrypt::certificates (
-  $whitelist = '*',
+  $whitelist    = '*',
+  $manage_hocon = false,
+  $sort_order   = 300,
 ) {
 
   # Matches when the agent node is the CA itself.
-  # Set up file mounts
   if $::fqdn == $::settings::ca_server {
+
+    # Set up file mountpoint to distribute the certs
     ini_setting { 'public certificates mountpoint path':
       ensure            => present,
-      path              => "${::settings::confdir}/fileserver.conf",
+      path              => $::settings::fileserverconfig,
       section           => 'public_certificates',
       setting           => 'path',
       key_val_separator => ' ',
       value             => "${::settings::ssldir}/ca/signed/",
     }
 
-    ini_setting { 'public certificates mountpoint whitelist':
-      ensure            => present,
-      path              => "${::settings::confdir}/fileserver.conf",
-      section           => 'public_certificates',
-      setting           => 'allow',
-      key_val_separator => ' ',
-      value             => $whitelist,
+    # Puppet 5 hard deprecated managing authentication in fileserver.conf
+    # which is too bad, because that was the only way to reliably associate a
+    # rule with a mount in an automated fashion.
+    if versioncmp($::puppetversion, '5.0.0') < 0 {
+      ini_setting { 'public certificates mountpoint whitelist':
+        ensure            => present,
+        path              => "${::settings::confdir}/fileserver.conf",
+        section           => 'public_certificates',
+        setting           => 'allow',
+        key_val_separator => ' ',
+        value             => $whitelist,
+      }
+    }
+    else {
+      # if we're on PE, we can assume a relatively modern & managed auth.conf
+      if defined('$::pe_server_version') {
+        pe_puppet_authorization::rule { 'public certificates mountpoint whitelist':
+          match_request_path   => '^/puppet/v3/file_(metadata|content)s?/public_certificates',
+          match_request_type   => 'regex',
+          match_request_method => 'get',
+          allow                => split($whitelist, ','),
+          sort_order           => 300,
+          path                 => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+        }
+      }
+      else {
+        # We can't actually do this automatically because we have no way of knowing
+        # whether the machine is configured with legacy auth.conf or HOCON.
+        if $manage_hocon {
+          puppet_authorization::rule { 'public certificates mountpoint whitelist':
+            match_request_path   => '^/puppet/v3/file_(metadata|content)s?/public_certificates',
+            match_request_type   => 'regex',
+            match_request_method => 'get',
+            allow                => split($whitelist, ','),
+            sort_order           => $sort_order,
+            path                 => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+          }
+        }
+        elsif $whitelist {
+          # If the user has specified a whitelist, but haven't indicated that they're
+          # using HOCON, we don't have any option but to fail and ask them to configure
+          # manually (and then set the parameters of this class appropriately).
+          fail("Node Encrypt: As of Puppet 5, it's no longer possible to reliably manage the whitelist automatically on Open Source Puppet. See https://github.com/binford2k/binford2k-node_encrypt#managing-certificates-on-open-source-puppet-5 for more information on configuring this manually.")
+        }
+        else {
+          # noop
+        }
+      }
     }
 
   }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
   "project_page": "https://github.com/binford2k/binford2k-node_encrypt",
   "issues_url": "https://github.com/binford2k/binford2k-node_encrypt/issues",
   "dependencies": [
-    {"name":"puppetlabs/inifile","version_requirement":">= 1.4.0 < 5.0.0"}
+    {"name":"puppetlabs/inifile",                  "version_requirement":">= 1.4.0 < 5.0.0" },
+    {"name":"puppetlabs/puppet_authorization",     "version_requirement":">= 0.4.0"         }
   ],
   "operatingsystem_support": [
     {
@@ -101,14 +102,7 @@
     }
   ],
   "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": ">=3.0.0"
-    },
-    {
-      "name": "puppet",
-      "version_requirement": ">=3.0.0 <5.0.0"
-    }
+    { "name": "puppet",   "version_requirement": ">=3.0.0 <6.0.0" }
   ]
 }
 


### PR DESCRIPTION
This will do its best to manage the certificate access on Puppet 5.
Unfortunately, it's not reasonably possible to do if the machine is
using legacy auth.conf, and there's not a good way to tell whether that
is the case on OSS. Therefore, we fail out and require the user to
either indicate that they're using HOCON, or to not manage the
whitelist. We fail by default because requiring a minor change in
classification is better than a false sense of security.

Tangent: since they're public certificates, I'm not even convinced that
it's worth trying to protect them. Perhaps it's time to just drop the
whitelist idea completely?

Fixes #18