### PR TITLE
This should be a != compare as if the node's puppet server is not the…

### DIFF
--- a/manifests/certificates.pp
+++ b/manifests/certificates.pp
@@ -74,9 +74,12 @@ class node_encrypt::certificates (
     }
 
   }
-  # Compiled on the CA, meaning that the agent is a compile master client of the CA
-  # Synch all agent certificates so we can encrypt for them
-  elsif $servername != $::settings::ca_server {
+  # Sync all agent certificates so we can encrypt for them.
+  # This will distribute the *public* certificates to all nodes, including other agents. This
+  # is not a security risk, as that's how public certificates were designed to be used, but if
+  # you'd like to limit this anyway, then simply ensure that this class is only enforced on the
+  # CA and any masters in your infrastructure.
+  else {
     file { "${::settings::ssldir}/certs":
       ensure  => directory,
       recurse => true,
@@ -84,8 +87,5 @@ class node_encrypt::certificates (
       source  => "puppet://${::settings::ca_server}/public_certificates/", # lint:ignore:puppet_url_without_modules
     }
   }
-  # Otherwise, we're just an agent node.
-  else {
-    # noop
-  }
+  
 }

--- a/manifests/certificates.pp
+++ b/manifests/certificates.pp
@@ -76,7 +76,7 @@ class node_encrypt::certificates (
   }
   # Compiled on the CA, meaning that the agent is a compile master client of the CA
   # Synch all agent certificates so we can encrypt for them
-  elsif $servername == $::settings::ca_server {
+  elsif $servername != $::settings::ca_server {
     file { "${::settings::ssldir}/certs":
       ensure  => directory,
       recurse => true,


### PR DESCRIPTION
… CA server (this means folks have a different CA than master) then configure this resource to copy over the public certs from the fileserver endpoint created.

In my puppet env we have our puppet master separate from the CA server. With the code prior to this change, nothing happened on the master where the certificates class was present. When I changed this compare it did what I would expect. I don't think we need to have those certs synced if the puppet server is the same as the CA since it'll already have everything, yes?