### PR TITLE
Support Sensitive values to node_encrypt::file

### DIFF
--- a/lib/puppet/parser/functions/node_encrypt.rb
+++ b/lib/puppet/parser/functions/node_encrypt.rb
@@ -4,11 +4,17 @@ Puppet::Parser::Functions::newfunction(:node_encrypt,
   :type  => :rvalue,
   :arity => 1,
   :doc   => <<DOC
-This function simply encrypts the string passed to it using the certificate
+This function simply encrypts the String or Sensitive passed to it using the certificate
 belonging to the client the catalog is being compiled for.
 DOC
 ) do |args|
-  content  = args.first
+  content = args.first
+  if defined?(Puppet::Pops::Types::PSensitiveType::Sensitive) && content.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+    content = content.unwrap
+  else
+    content = content
+  end
+
   certname = self.lookupvar('clientcert')
   Puppet_X::Binford2k::NodeEncrypt.encrypt(content, certname)
 end


### PR DESCRIPTION
This automatically unwraps `Sensitive` values in the `node_encrypt` function.

If the `Sensitive` type isn't known (it was released in Puppet 4.6), this behaves as before.

I tried this on our 2019.0 server, and passing a `Sensitive` worked fine.