### PR TITLE
Disable verification for Puppet 6 certificate chain

### DIFF
--- a/lib/puppet_x/binford2k/node_encrypt.rb
+++ b/lib/puppet_x/binford2k/node_encrypt.rb
@@ -47,7 +47,7 @@ module Puppet_X
         decrypted = blob.decrypt(key, cert)
         verified  = OpenSSL::PKCS7.new(decrypted)
 
-        unless verified.verify(nil, store, nil, OpenSSL::PKCS7::NOCHAIN)
+        unless verified.verify(nil, store, nil, OpenSSL::PKCS7::NOVERIFY)
           raise ArgumentError, 'Signature verification failed'
         end
         verified.data


### PR DESCRIPTION
Hey @magisus, think I could get a little help encrypting/decrypting properly with the new certificate chain so that I don't have to disable verification like this?