### PR TITLE
Remove serialized class from transactionstore

### DIFF
--- a/lib/puppet_x/binford2k/node_encrypt.rb
+++ b/lib/puppet_x/binford2k/node_encrypt.rb
@@ -88,6 +88,13 @@ module Puppet_X
         def to_s
           '<<encrypted>>'
         end
+
+        # The transactionstore uses psych to dump yaml to the cache file.
+        # This lets us control how that is serialized.
+        def encode_with(coder)
+          coder.tag = nil
+          coder.scalar = '<<encrypted>>'
+        end
       end
 
     end


### PR DESCRIPTION
Puppet tries to persist data between runs for use in calculating
intentional change vs. unintentional drift. Unfortunately, it's just
yaml serialized to disk, meaning both that it's an invalid class when
Puppet tries to reload it for the next run, and it means that the plain
text form of the secret was written to cache. Bad Puppet!

This corrects both of those issues, with the slight side effect that
node_encrypt files probably won't ever show up as intentional change if
the content is modified after the first write. That's not a huge deal,
but I'm tracking it in #42 for eventual correction.

Fixes #34
Co-authored-by: Aleksei <lexa@ihpu.org>