### PR TITLE
certificates: Do not purge cached ca.pem.

### DIFF
--- a/manifests/certificates.pp
+++ b/manifests/certificates.pp
@@ -79,7 +79,7 @@ class node_encrypt::certificates (
       ensure  => directory,
       recurse => true,
       purge   => true,
-      ignore  => 'pe-internal-*',
+      ignore  => [ 'pe-internal-*', 'ca.pem' ],
       source  => "puppet://${::settings::ca_server}/public_certificates/", # lint:ignore:puppet_url_without_modules
     }
   }


### PR DESCRIPTION
Purging that leads to failure on puppetserver
restart.