### PR TITLE
Add alternate of sending clientcert as fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,23 @@ Parameters:
       order here. The default rule's weight is 500, so this parameter defaults to
       `300` to ensure that it overrides the default.
 
+#### Distributing certificates via a custom fact.
+
+If you cannot sync agent public certificates to your compile masters, you can also
+send them with the catalog request from the agent with a custom fact. Place this
+file in `/etc/puppetlabs/facter/facts.d/clientcert_pem.rb` on each agent node and
+make it executable with `chmod +x` or mode `0755`.
+
+```Ruby
+#! /opt/puppetlabs/puppet/bin/ruby
+require 'puppet'
+Puppet.initialize_settings
+
+hostcert = File.read(Puppet.settings[:hostcert])
+factdata = { 'clientcert_pem' => hostcert }
+
+puts JSON.pretty_generate factdata
+```
 
 ### Legacy Puppet 5 and below support
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ and then decrypt it on that node. If you like, you may also paste the ciphertext
 into your manifest or Hiera datafiles and then manually invoke the `node_decrypt()`
 function as needed.
 
-**Note**: Because it requires access to each node's signed certificates, this is
-only useful on the CA node unless you distribute certificates or generate
-encrypted blocks on the CA using the `puppet node encrypt` face. There is a class
-included to automate the public certificate distribution.
 
 ## Usage
 
@@ -170,10 +166,12 @@ You can then decrypt this data by:
 
 ### Automatically distributing certificates to compile masters
 
-The `node_encrypt::certificates` class can synchronize certificates across your
-infrastructure so that encryption works from all compile masters. Please be aware
-that **this class will create a fileserver mount on the CA node** making public
-certificates available for download by all nodes.
+The agent should send its public certificate as a custom `clientcert_pem` fact,
+making this a seamless zero-config process. In the case that doesn't work, you
+can distribute certificates to your compile masters using the
+`node_encrypt::certificates` class so that encryption works from all compile
+masters. Please be aware that **this class will create a fileserver mount on the
+CA node** making public certificates available for download by all nodes.
 
 Classify all your masters, including the CA or Master of Masters, with this class.
 This will ensure that all masters have all agents' public certificates.
@@ -197,23 +195,6 @@ Parameters:
       order here. The default rule's weight is 500, so this parameter defaults to
       `300` to ensure that it overrides the default.
 
-#### Distributing certificates via a custom fact.
-
-If you cannot sync agent public certificates to your compile masters, you can also
-send them with the catalog request from the agent with a custom fact. Place this
-file in `/etc/puppetlabs/facter/facts.d/clientcert_pem.rb` on each agent node and
-make it executable with `chmod +x` or mode `0755`.
-
-```Ruby
-#! /opt/puppetlabs/puppet/bin/ruby
-require 'puppet'
-Puppet.initialize_settings
-
-hostcert = File.read(Puppet.settings[:hostcert])
-factdata = { 'clientcert_pem' => hostcert }
-
-puts JSON.pretty_generate factdata
-```
 
 ### Legacy Puppet 5 and below support
 

--- a/lib/facter/clientcert_pem.rb
+++ b/lib/facter/clientcert_pem.rb
@@ -1,0 +1,5 @@
+Facter.add(:clientcert_pem) do
+  setcode do
+    File.read(Puppet.settings[:hostcert])
+  end
+end

--- a/lib/puppet_x/binford2k/node_encrypt.rb
+++ b/lib/puppet_x/binford2k/node_encrypt.rb
@@ -15,6 +15,15 @@ module Puppet_X
         certpath = Puppet.settings[:hostcert]
         keypath  = Puppet.settings[:hostprivkey]
 
+        # A dummy password with at least 4 characters is required here
+        # since Ruby 2.4 which enforces a minimum password length
+        # of 4 bytes. This is true even if the key has no password
+        # at all--in which case the password we supply is ignored.
+        # We can pass in a dummy here, since we know the certificate
+        # has no password.
+        key  = OpenSSL::PKey::RSA.new(File.read(keypath), '1234')
+        cert = OpenSSL::X509::Certificate.new(File.read(certpath))
+
         # if we're on the CA, we've got a copy of the clientcert from the start.
         # This allows the module to work with no classification at all on single
         # monolithic master setups
@@ -23,22 +32,20 @@ module Puppet_X
           "#{Puppet.settings[:certdir]}/#{destination}.pem",
         ].find {|path| File.exist? path }
 
-        # A dummy password with at least 4 characters is required here
-        # since Ruby 2.4 which enforces a minimum password length
-        # of 4 bytes. This is true even if the key has no password
-        # at all--in which case the password we supply is ignored.
-        # We can pass in a dummy here, since we know the certificate
-        # has no password.
-        key    = OpenSSL::PKey::RSA.new(File.read(keypath), '1234')
-        cert   = OpenSSL::X509::Certificate.new(File.read(certpath))
-
+        # for safer upgrades, let's default to the known good pathway for now
         if destpath
           target = OpenSSL::X509::Certificate.new(File.read(destpath))
-        elsif Puppet.lookup(:global_scope).exist?('clientcert_pem')
-          hostcert = Puppet.lookup(:global_scope).lookupvar('clientcert_pem')
-          target   = OpenSSL::X509::Certificate.new(hostcert)
         else
-          raise ArgumentError, 'Client certificate does not exist. See https://github.com/binford2k/binford2k-node_encrypt#automatically-distributing-certificates-to-compile-masters'
+          # if we don't have a cert, check for it in $facts
+          scope = Puppet.lookup(:global_scope)
+
+          if scope.exist?('clientcert_pem')
+            hostcert = scope.lookupvar('clientcert_pem')
+            target   = OpenSSL::X509::Certificate.new(hostcert)
+          else
+            url = 'https://github.com/binford2k/binford2k-node_encrypt#automatically-distributing-certificates-to-compile-masters'
+            raise ArgumentError, "Client certificate does not exist. See #{url} for more info."
+          end
         end
 
         signed = OpenSSL::PKCS7::sign(cert, key, data, [], OpenSSL::PKCS7::BINARY)

--- a/spec/unit/puppet_x/binford2k/node_encrypt_spec.rb
+++ b/spec/unit/puppet_x/binford2k/node_encrypt_spec.rb
@@ -262,10 +262,14 @@ describe Puppet_X::Binford2k::NodeEncrypt do
               '/etc/puppetlabs/puppet/ssl/private_keys/master.example.com.pem',  # encrypting for agent
               '/etc/puppetlabs/puppet/ssl/private_keys/testhost.example.com.pem' # decrypting on agent
             )
+    Puppet.settings.expects(:[]).with(:signeddir).returns('/bad/path')                                 # fall through to certdir
     Puppet.settings.expects(:[]).with(:certdir).returns('/etc/puppetlabs/puppet/ssl/certs')            # encrypting for agent
     Puppet.settings.expects(:[]).with(:localcacert).returns('/etc/puppetlabs/puppet/ssl/certs/ca.pem') # decrypting as agent
 
     # encrypting on master for agent
+    File.expects(:exist?).with(regexp_matches(/bad\/path\/testhost.example.com\.pem$/)).returns(nil)
+    File.expects(:exist?).with(regexp_matches(/ssl\/certs\/testhost.example.com\.pem$/)).returns(true)
+
     File.expects(:read).with(regexp_matches(/ssl\/certs\/master.example.com\.pem$/)).returns(ca_crt_pem)
     File.expects(:read).with(regexp_matches(/ssl\/private_keys\/master.example.com\.pem$/)).returns(ca_key_pem)
     File.expects(:read).with(regexp_matches(/ssl\/certs\/testhost\.example\.com\.pem$/)).returns(cert_pem)


### PR DESCRIPTION
This just adds instructions for exposing the contents of the client's
hostcert as a custom fact. The compiling master will use the contents
of that fact if it doesn't already have the certificate on disk.

Update: now switched to always-on native fact. It still defaults to looking for the clientcert on disk, just to be cautious.

Fixes #13