### PR TITLE
Allow node_encrypt::secret to accept Sensitive[String] values

### DIFF
--- a/functions/secret.pp
+++ b/functions/secret.pp
@@ -1,3 +1,3 @@
-function node_encrypt::secret(String $data) >> Deferred {
+function node_encrypt::secret(Variant[String, Sensitive[String]] $data) >> Deferred {
   Deferred("node_decrypt", [node_encrypt($data)])
 }


### PR DESCRIPTION
This fixes #51. Previously `node_encrypt::secret()` would only take `String` values as an argument. The underlying code supports both, so this is a trivial fix.

---

I haven't been able to test this yet, because I only have a masterless set up here. When I get a chance I'll give it a real try.