### PR TITLE
Skip decrypting if running under OnceOver

### DIFF
--- a/lib/puppet_x/binford2k/node_encrypt.rb
+++ b/lib/puppet_x/binford2k/node_encrypt.rb
@@ -81,7 +81,7 @@ module Puppet_X
         attr_accessor :decrypted_value
 
         def initialize(value)
-          if Puppet_X::Binford2k::NodeEncrypt.encrypted? value
+          if Puppet_X::Binford2k::NodeEncrypt.encrypted? value and not defined?($onceover_node)
             @decrypted_value = Puppet_X::Binford2k::NodeEncrypt.decrypt(value)
           else
             @decrypted_value = value


### PR DESCRIPTION
This checks to see if you're running under OnceOver so you can
acceptance test your control repo without setting up the full Puppet PKI
system first or mocking out some deep Ruby magic.

Yes, it's Volkswagening, but it seems like the least annoying
alternative? 🤷‍♀️

What do you think about this, @dylanratcliffe?